### PR TITLE
Add the possibility to connect to the StateExt ports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,8 @@ find_package(Eigen3 REQUIRED)
 
 ### Options
 # Shared/Dynamic or Static library?
-option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" ON)
+# Setting BUILD_SHARED_LIBS to false by default to make sure that the ReadOnlyControlBoardPlugin is found also without installing.
+option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" OFF)
 
 # Build test related commands?
 option(BUILD_TESTING "Create tests using CMake" OFF)

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -1,2 +1,4 @@
+yarp_begin_plugin_library(ReadOnlyRemoteControlBoardLib)
 add_subdirectory(ReadOnlyRemoteControlBoard)
+yarp_end_plugin_library(ReadOnlyRemoteControlBoardLib)
 add_subdirectory(Utilities)

--- a/src/lib/ReadOnlyRemoteControlBoard/ReadOnlyRemoteControlBoard.cpp
+++ b/src/lib/ReadOnlyRemoteControlBoard/ReadOnlyRemoteControlBoard.cpp
@@ -198,8 +198,10 @@ namespace dev {
     bool ReadOnlyRemoteControlBoard::getAxes(int *ax)
     {
         if (!ax) return false;
-        *ax = m_numberOfJoints;
-        return true;
+        m_extendedPortMutex.wait();
+        bool ret = m_extendedIntputStatePort.getJointPositionSize(*ax); //It is possible that the joint size provided in the configuration do not match what it is read from stateExt
+        m_extendedPortMutex.post();
+        return ret;
     }
 
     bool ReadOnlyRemoteControlBoard::getEncoder(int j, double *v)

--- a/src/lib/ReadOnlyRemoteControlBoard/stateExtendedReader.cpp
+++ b/src/lib/ReadOnlyRemoteControlBoard/stateExtendedReader.cpp
@@ -325,3 +325,11 @@ void StateExtendedInputPort::getEstFrequency(int &ite, double &av, double &min, 
     av=av*1000;
     mutex.unlock();
 }
+
+bool StateExtendedInputPort::getJointPositionSize(int &size)
+{
+    mutex.lock();
+    size = last.jointPosition.size();
+    mutex.unlock();
+    return true;
+}

--- a/src/lib/ReadOnlyRemoteControlBoard/stateExtendedReader.h
+++ b/src/lib/ReadOnlyRemoteControlBoard/stateExtendedReader.h
@@ -83,6 +83,8 @@ public:
 
     // time is in ms
     void getEstFrequency(int &ite, double &av, double &min, double &max);
+
+    bool getJointPositionSize(int& size);
 };
 
 #endif // YARP_DEV_REMOTECONTROLBOARD_STATEEXTENDEDREADER_H

--- a/src/modules/idyntree-yarp-visualizer/CMakeLists.txt
+++ b/src/modules/idyntree-yarp-visualizer/CMakeLists.txt
@@ -1,7 +1,9 @@
 set(MODULE_NAME idyntree-yarp-visualizer)
 
-set (HDR Visualizer.h)
-set (SRC main.cpp Visualizer.cpp)
+set (HDR Visualizer.h
+         RobotConnectors.h)
+set (SRC main.cpp Visualizer.cpp
+                  RobotConnectors.cpp)
 set (THRIFTS thrifts/VisualizerCommands.thrift)
 
 yarp_add_idl(THRIFT_GEN_FILES ${THRIFTS})

--- a/src/modules/idyntree-yarp-visualizer/CMakeLists.txt
+++ b/src/modules/idyntree-yarp-visualizer/CMakeLists.txt
@@ -12,3 +12,5 @@ add_executable(${MODULE_NAME} ${SRC} ${HDR} ${THRIFT_GEN_FILES})
 target_link_libraries(${MODULE_NAME} PRIVATE idyntree-yarp-utilities ReadOnlyRemoteControlBoardLib Eigen3::Eigen
                                              iDynTree::idyntree-core iDynTree::idyntree-modelio-urdf iDynTree::idyntree-visualization
                                              ${YARP_LIBRARIES})
+
+install(TARGETS ${MODULE_NAME} DESTINATION bin)

--- a/src/modules/idyntree-yarp-visualizer/CMakeLists.txt
+++ b/src/modules/idyntree-yarp-visualizer/CMakeLists.txt
@@ -9,6 +9,6 @@ set (THRIFTS thrifts/VisualizerCommands.thrift)
 yarp_add_idl(THRIFT_GEN_FILES ${THRIFTS})
 
 add_executable(${MODULE_NAME} ${SRC} ${HDR} ${THRIFT_GEN_FILES})
-target_link_libraries(${MODULE_NAME} PRIVATE idyntree-yarp-utilities Eigen3::Eigen
+target_link_libraries(${MODULE_NAME} PRIVATE idyntree-yarp-utilities ReadOnlyRemoteControlBoardLib Eigen3::Eigen
                                              iDynTree::idyntree-core iDynTree::idyntree-modelio-urdf iDynTree::idyntree-visualization
                                              ${YARP_LIBRARIES})

--- a/src/modules/idyntree-yarp-visualizer/README.md
+++ b/src/modules/idyntree-yarp-visualizer/README.md
@@ -1,0 +1,31 @@
+# idyntree-yarp-visualizer
+
+This module allows visualing a robot starting from its URDF. 
+
+![image](https://user-images.githubusercontent.com/18591940/115052071-cda47400-9edd-11eb-962a-c136abf2bfdb.png)
+
+## How to run
+The module relies on a set of parameters. For each of them, a default value is specified, so the module can simply run with the command
+
+```
+idyntree-yarp-visualizer
+```
+By default, it looks for the robot URDF model with name ``model.urdf``, searched according to the ``YARP_ROBOT_NAME``. It will then trying to connect to the robot according to the list of joints reported in the model.
+
+The configuration of the visualizer can be changed via configuration file or by command line arguments. Run the following command to have the full list of parameters and their default
+```
+idyntree-yarp-visualizer --help
+```
+
+### Ports opened
+
+By default, the ``idyntree-yarp-visualizer``  opens two ports
+
+- A RPC port for a basic interaction with the visualizer. By default, the port name is ``/idyntree-yarp-visualizer/rpc``.  Use the command ``help`` to get a list of possible commands. Run ``help <commandName>`` to get informations about a specific command.
+```
+yarp rpc /idyntree-yarp-visualizer/rpc
+>>help
+```
+- A port streaming the visualization output. By default, this port is named ``/idyntree-yarp-visualizer/image``, and allows to see the visualizer output remotely.
+
+According to the method adopted to connect to the robot, the module will open other ports for internal use.

--- a/src/modules/idyntree-yarp-visualizer/README.md
+++ b/src/modules/idyntree-yarp-visualizer/README.md
@@ -1,6 +1,6 @@
 # idyntree-yarp-visualizer
 
-This module allows visualing a robot starting from its URDF. 
+This module allows visualizing a robot starting from its URDF.
 
 ![image](https://user-images.githubusercontent.com/18591940/115052071-cda47400-9edd-11eb-962a-c136abf2bfdb.png)
 

--- a/src/modules/idyntree-yarp-visualizer/RobotConnectors.cpp
+++ b/src/modules/idyntree-yarp-visualizer/RobotConnectors.cpp
@@ -30,7 +30,7 @@ bool RemapperConnector::getOrGuessControlBoardsFromFile(const yarp::os::Searchab
             yarp::os::Value cbValue = controlBoardsList->get(i);
             if (!cbValue.isString())
             {
-                yError() << "The value in position " << i << " (0-based) of controlBoards is not a string.";
+                yError() << "The value in position" << i << "(0-based) of controlBoards is not a string.";
                 return false;
             }
             m_controlBoards.push_back(cbValue.asString());
@@ -78,7 +78,7 @@ bool RemapperConnector::getJointNamesFromModel(const yarp::os::Searchable &input
             yarp::os::Value jvalue = jointList->get(i);
             if (!jvalue.isString())
             {
-                yError() << "The value in position " << i << " (0-based) of joints is not a string.";
+                yError() << "The value in position" << i << "(0-based) of joints is not a string.";
                 return false;
             }
             m_basicInfo->jointList.push_back(jvalue.asString());
@@ -209,14 +209,14 @@ bool StateExtConnector::getAxesDescription(const yarp::os::Value &inputValue)
         yarp::os::Value& cbName = cbJointList->get(i);
         if (!cbName.isString())
         {
-            yError() << "The element in position " << i << " (0-based) of the connectToStateExt list is supposed to be a string, namely the name of the control board.";
+            yError() << "The element in position" << i << "(0-based) of the connectToStateExt list is supposed to be a string, namely the name of the control board.";
             return false;
         }
 
         yarp::os::Value& jointListValue = cbJointList->get(i+1);
         if (!jointListValue.isList())
         {
-            yError() << "The element in position " << i+1 << " (0-based) of the connectToStateExt list is supposed to be a list, namely the list of joints of the specific control board.";
+            yError() << "The element in position" << i+1 << "(0-based) of the connectToStateExt list is supposed to be a list, namely the list of joints of the specific control board.";
             return false;
         }
 
@@ -240,9 +240,9 @@ bool StateExtConnector::getAxesDescription(const yarp::os::Value &inputValue)
 
                 if (jointBottle->size() != 2)
                 {
-                    yError() << "The element at position " << j << " (0-based) of the control board \""
-                             << m_cb_jointsMap.back().first << "\" is malformed. It has "
-                             << jointBottle->size() << ", but it is supposed to have 2.";
+                    yError() << "The element at position" << j << "(0-based) of the control board"
+                             << m_cb_jointsMap.back().first << "is malformed. It has"
+                             << jointBottle->size() << "but it is supposed to have 2.";
                     return false;
                 }
 
@@ -250,9 +250,9 @@ bool StateExtConnector::getAxesDescription(const yarp::os::Value &inputValue)
 
                 if (!jointNameValue.isString())
                 {
-                    yError() << "The element at position " << j << " (0-based) of the control board \""
-                             << m_cb_jointsMap.back().first << "\" is malformed."
-                             << " The first element is supposed to be the name of the joint, but it is not a string.";
+                    yError() << "The element at position" << j << "(0-based) of the control board"
+                             << m_cb_jointsMap.back().first << "is malformed."
+                             << "The first element is supposed to be the name of the joint, but it is not a string.";
                     return false;
                 }
 
@@ -260,14 +260,14 @@ bool StateExtConnector::getAxesDescription(const yarp::os::Value &inputValue)
 
                 if (!joinTypeValue.isString())
                 {
-                    yError() << "The element at position " << j << " (0-based) of the control board \""
-                             << m_cb_jointsMap.back().first << "\" is malformed."
-                             << " The second element is supposed to be the type of the joint, but it is not a string.";
+                    yError() << "The element at position" << j << "(0-based) of the control board"
+                             << m_cb_jointsMap.back().first << "is malformed."
+                             << "The second element is supposed to be the type of the joint, but it is not a string.";
                     return false;
                 }
 
                 JointInfo newJoint;
-                newJoint.name = joinTypeValue.asString();
+                newJoint.name = jointNameValue.asString();
 
                 std::string jointTypeString = joinTypeValue.asString();
                 std::transform(jointTypeString.begin(), jointTypeString.end(), jointTypeString.begin(),
@@ -283,10 +283,10 @@ bool StateExtConnector::getAxesDescription(const yarp::os::Value &inputValue)
                 }
                 else
                 {
-                    yError() << "The element at position " << j << " (0-based) of the control board \""
-                             << m_cb_jointsMap.back().first << "\" is malformed."
-                             << " The second element is supposed to be the type of the joint, but the value "
-                             << joinTypeValue.asString() << " is not recognized. Supported values are \"p\" or \"prismatic\" "
+                    yError() << "The element at position" << j << "(0-based) of the control board"
+                             << m_cb_jointsMap.back().first << "is malformed."
+                             << "The second element is supposed to be the type of the joint, but the value"
+                             << joinTypeValue.asString() << "is not recognized. Supported values are \"p\" or \"prismatic\""
                              << "for prismatic joints, and \"r\" and \"revolute\" for revolute joints.";
                     return false;
                 }
@@ -295,9 +295,9 @@ bool StateExtConnector::getAxesDescription(const yarp::os::Value &inputValue)
             }
             else
             {
-                yError() << "The element at position " << j << " (0-based) of the control board \""
-                         << m_cb_jointsMap.back().first << "\" is malformed."
-                         <<" It is supposed to be either a string or a list of two elements (the joint name and the joint type).";
+                yError() << "The element at position" << j <<"(0-based) of the control board"
+                         << m_cb_jointsMap.back().first << "is malformed."
+                         <<"It is supposed to be either a string or a list of two elements (the joint name and the joint type).";
                 return false;
             }
 
@@ -384,13 +384,13 @@ bool StateExtConnector::connectToRobot()
 
             if (!m_encodersInterfaces[i].device->open(stateExtCbOptions))
             {
-                yError() << "Failed to open readonlyremotecontrolboard device for the " << m_cb_jointsMap[i].first << " control board.";
+                yError() << "Failed to open readonlyremotecontrolboard device for the" << m_cb_jointsMap[i].first << "control board.";
                 return false;
             }
 
             if (!m_encodersInterfaces[i].device->view(m_encodersInterfaces[i].encoders))
             {
-                yError() << "Failed to view encoder interface for the " << m_cb_jointsMap[i].first << " control board.";
+                yError() << "Failed to view encoder interface for the" << m_cb_jointsMap[i].first << "control board.";
                 return false;
             }
 
@@ -422,9 +422,9 @@ bool StateExtConnector::getJointValues(iDynTree::VectorDynSize &jointValuesInRad
             {
                 if (numberOfJoints != static_cast<int>(m_encodersInterfaces[cb].jointsBuffer.size()))
                 {
-                    yError() << "The number of joints for the control board " << m_cb_jointsMap[cb].first
-                             << " appears to be " << numberOfJoints << ", while it has been configured with "
-                             << m_encodersInterfaces[cb].jointsBuffer.size() << " joints. Closing the connection.";
+                    yError() << "The number of joints for the control board" << m_cb_jointsMap[cb].first
+                             << "appears to be" << numberOfJoints << "while it has been configured with"
+                             << m_encodersInterfaces[cb].jointsBuffer.size() << "joints. Closing the connection.";
                     shouldClose = true;
                     break;
                 }
@@ -439,7 +439,6 @@ bool StateExtConnector::getJointValues(iDynTree::VectorDynSize &jointValuesInRad
                 }
             }
         }
-        assert(currentPosition == jointValuesInRad.size());
     }
 
     if (shouldClose)

--- a/src/modules/idyntree-yarp-visualizer/RobotConnectors.cpp
+++ b/src/modules/idyntree-yarp-visualizer/RobotConnectors.cpp
@@ -52,6 +52,8 @@ bool RemapperConnector::getJointNamesFromModel(const yarp::os::Searchable &input
 
     if (jointsValue.isNull())
     {
+        yInfo() << "Retrieving the list of joints from the model.";
+
         for (size_t i = 0; i < model.getNrOfJoints(); ++i)
         {
             if (model.getJoint(i)->getNrOfDOFs() == 1)
@@ -264,6 +266,13 @@ bool StateExtConnector::getAxesDescription(const yarp::os::Value &inputValue)
 
         yarp::os::Bottle* jointList = jointListValue.asList();
 
+        if (m_cb_jointsMap.back().jointsToConsider > static_cast<int>(jointList->size()))
+        {
+            yError() << "It has been specified to consider"<< m_cb_jointsMap.back().jointsToConsider
+                     << "joints, but only" << jointList->size() << "are listed.";
+            return false;
+        }
+
         for (size_t j = 0; j < jointList->size(); ++j)
         {
             yarp::os::Value& jointValue = jointList->get(j);
@@ -379,23 +388,29 @@ bool StateExtConnector::configure(const yarp::os::Searchable &inputConf, std::sh
 
         if (robotLocalName == "icubSim")
         {
-            confValue.fromString("(head, (neck_pitch, neck_roll, neck_yaw),"
-                                 " torso, (torso_yaw, torso_pitch, torso_roll),"
-                                 " left_arm, (l_shoulder_pitch, l_shoulder_roll, l_shoulder_yaw, l_elbow, l_wrist_prosup, l_wrist_pitch, l_wrist_yaw),"
-                                 " right_arm, (r_shoulder_pitch, r_shoulder_roll, r_shoulder_yaw, r_elbow, r_wrist_prosup, r_wrist_pitch, r_wrist_yaw),"
-                                 " left_leg, (l_hip_pitch, l_hip_roll, l_hip_yaw, l_knee, l_ankle_pitch, l_ankle_roll),"
-                                 " right_leg, (r_hip_pitch, r_hip_roll, r_hip_yaw, r_knee, r_ankle_pitch, r_ankle_roll))");
+            std::string defaultString = "(head, (neck_pitch, neck_roll, neck_yaw),"
+                                        " torso, (torso_yaw, torso_pitch, torso_roll),"
+                                        " left_arm, (l_shoulder_pitch, l_shoulder_roll, l_shoulder_yaw, l_elbow, l_wrist_prosup, l_wrist_pitch, l_wrist_yaw),"
+                                        " right_arm, (r_shoulder_pitch, r_shoulder_roll, r_shoulder_yaw, r_elbow, r_wrist_prosup, r_wrist_pitch, r_wrist_yaw),"
+                                        " left_leg, (l_hip_pitch, l_hip_roll, l_hip_yaw, l_knee, l_ankle_pitch, l_ankle_roll),"
+                                        " right_leg, (r_hip_pitch, r_hip_roll, r_hip_yaw, r_knee, r_ankle_pitch, r_ankle_roll))";
+            confValue.fromString(defaultString.c_str());
+
+            yInfo() << "Using default StateExt configuration for robot icubSim. Corresponding command: \n--connectToStateExt " + defaultString + "\"";
         }
         else if (robotLocalName == "icub")
         {
-            confValue.fromString("((head, 3), (neck_pitch, neck_roll, neck_yaw, eyes_tilt, eyes_vers, eyes_verg),"
-                                 " torso, (torso_roll, torso_pitch, torso_yaw),"
-                                 " (left_arm, 7), (l_shoulder_pitch, l_shoulder_roll, l_shoulder_yaw, l_elbow, l_wrist_prosup, l_wrist_pitch, l_wrist_yaw,"
-                                    " l_hand_finger, l_thumb_oppose, l_thumb_proximal, l_thumb_distal, l_index_proximal, l_index_distal, l_middle_proximal, l_middle_distal, l_little_fingers),"
-                                 " (right_arm, 7), (r_shoulder_pitch, r_shoulder_roll, r_shoulder_yaw, r_elbow, r_wrist_prosup, r_wrist_pitch, r_wrist_yaw,"
-                                    " r_hand_finger, r_thumb_oppose, r_thumb_proximal, r_thumb_distal, r_index_proximal, r_index_distal, r_middle_proximal, r_middle_distal, r_little_fingers),"
-                                 " left_leg, (l_hip_pitch, l_hip_roll, l_hip_yaw, l_knee, l_ankle_pitch, l_ankle_roll),"
-                                 " right_leg, (r_hip_pitch, r_hip_roll, r_hip_yaw, r_knee, r_ankle_pitch, r_ankle_roll))");
+            std::string defaultString = "((head, 3), (neck_pitch, neck_roll, neck_yaw, eyes_tilt, eyes_vers, eyes_verg),"
+                                        " torso, (torso_roll, torso_pitch, torso_yaw),"
+                                        " (left_arm, 7), (l_shoulder_pitch, l_shoulder_roll, l_shoulder_yaw, l_elbow, l_wrist_prosup, l_wrist_pitch, l_wrist_yaw,"
+                                           " l_hand_finger, l_thumb_oppose, l_thumb_proximal, l_thumb_distal, l_index_proximal, l_index_distal, l_middle_proximal, l_middle_distal, l_little_fingers),"
+                                        " (right_arm, 7), (r_shoulder_pitch, r_shoulder_roll, r_shoulder_yaw, r_elbow, r_wrist_prosup, r_wrist_pitch, r_wrist_yaw,"
+                                           " r_hand_finger, r_thumb_oppose, r_thumb_proximal, r_thumb_distal, r_index_proximal, r_index_distal, r_middle_proximal, r_middle_distal, r_little_fingers),"
+                                        " left_leg, (l_hip_pitch, l_hip_roll, l_hip_yaw, l_knee, l_ankle_pitch, l_ankle_roll),"
+                                        " right_leg, (r_hip_pitch, r_hip_roll, r_hip_yaw, r_knee, r_ankle_pitch, r_ankle_roll))";
+            confValue.fromString(defaultString.c_str());
+
+            yInfo() << "Using default StateExt configuration for robot icub. Corresponding command: \n--connectToStateExt \"" + defaultString + "\"";
         }
         else
         {

--- a/src/modules/idyntree-yarp-visualizer/RobotConnectors.cpp
+++ b/src/modules/idyntree-yarp-visualizer/RobotConnectors.cpp
@@ -203,7 +203,7 @@ bool StateExtConnector::getAxesDescription(const yarp::os::Value &inputValue)
     if (cbJointList->size() %2 != 0)
     {
         yError() << "The list provided after connectToStateExt is supposed to have an even number of elements."
-                 << "It is supposed to be a sequence of a list containing the name of the control board (and eventuually the number of joints to consider),"
+                 << "It needs to be a sequence of a list containing the name of the control board (and eventuually the number of joints to consider),"
                      "followed by the full list of joints in the control board.";
         return false;
     }

--- a/src/modules/idyntree-yarp-visualizer/RobotConnectors.cpp
+++ b/src/modules/idyntree-yarp-visualizer/RobotConnectors.cpp
@@ -123,6 +123,7 @@ bool RemapperConnector::connectToRobot()
     std::lock_guard<std::mutex> lock(m_mutex);
     {
         std::lock_guard<std::mutex> lock(m_basicInfo->mutex);
+        //First make sure to reset the device in case it was already opened.
         m_robotDevice.close();
         m_encodersInterface = nullptr;
 

--- a/src/modules/idyntree-yarp-visualizer/RobotConnectors.cpp
+++ b/src/modules/idyntree-yarp-visualizer/RobotConnectors.cpp
@@ -1,0 +1,131 @@
+#include <yarp/os/LogStream.h>
+#include <iDynTree/Core/Utils.h>
+#include "RobotConnectors.h"
+
+namespace idyntree_yarp_tools {
+
+bool RemapperConnector::getorGuessControlBoardsFromFile(const yarp::os::Searchable &inputConf)
+{
+    m_controlBoards.clear();
+    yarp::os::Value controlBoardsValue = inputConf.find("controlboards");
+
+    if (controlBoardsValue.isNull())
+    {
+        m_controlBoards = {"head", "torso", "left_arm", "right_arm", "left_leg", "right_leg"}; //assumes these as controlboards
+    }
+    else
+    {
+        if (!controlBoardsValue.isList())
+        {
+            yError() << "controlBoards is specified, but it is not a list.";
+            return false;
+        }
+
+        yarp::os::Bottle* controlBoardsList = controlBoardsValue.asList();
+
+        for (size_t i = 0; i < controlBoardsList->size(); ++i)
+        {
+            yarp::os::Value cbValue = controlBoardsList->get(i);
+            if (!cbValue.isString())
+            {
+                yError() << "The value in position " << i << " (0-based) of controlBoards is not a string.";
+                return false;
+            }
+            m_controlBoards.push_back(cbValue.asString());
+        }
+    }
+
+    return true;
+}
+
+bool RemapperConnector::configure(const yarp::os::Searchable &inputConf, std::shared_ptr<BasicInfo> basicInfo)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    if (!getorGuessControlBoardsFromFile(inputConf))
+    {
+        return false;
+    }
+
+    m_basicInfo = basicInfo;
+
+    {
+        std::lock_guard<std::mutex>(m_basicInfo->mutex);
+
+        m_jointsInDeg.resize(m_basicInfo->jointList.size());
+    }
+
+    return true;
+}
+
+bool RemapperConnector::connectToRobot()
+{
+    m_connected = false;
+
+    std::lock_guard<std::mutex> lock(m_mutex);
+    {
+        std::lock_guard<std::mutex> lock(m_basicInfo->mutex);
+        m_robotDevice.close();
+        m_encodersInterface = nullptr;
+
+        yarp::os::Property remapperOptions;
+        remapperOptions.put("device", "remotecontrolboardremapper");
+        yarp::os::Bottle axesNames;
+        yarp::os::Bottle & axesList = axesNames.addList();
+        for (auto& joint : m_basicInfo->jointList)
+        {
+            axesList.addString(joint);
+        }
+        remapperOptions.put("axesNames",axesNames.get(0));
+
+        yarp::os::Bottle remoteControlBoards;
+        yarp::os::Bottle & remoteControlBoardsList = remoteControlBoards.addList();
+        for (auto& cb : m_controlBoards)
+        {
+            remoteControlBoardsList.addString("/" + m_basicInfo->robotPrefix + "/" + cb);
+        }
+        remapperOptions.put("remoteControlBoards",remoteControlBoards.get(0));
+        remapperOptions.put("localPortPrefix", "/" + m_basicInfo->name +"/remoteControlBoard:i");
+
+        if(!m_robotDevice.open(remapperOptions))
+        {
+            yError() << "Failed to open remote control board remapper.";
+            return false;
+        }
+        if (!m_robotDevice.view(m_encodersInterface) || !m_encodersInterface)
+        {
+            yError() << "Failed to view encoder interface.";
+
+            return false;
+        }
+    }
+
+    m_connected = true;
+    return true;
+}
+
+bool RemapperConnector::getJointValues(iDynTree::VectorDynSize &jointValuesInRad)
+{
+    if (m_connected)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+
+        if (m_encodersInterface->getEncoders(m_jointsInDeg.data()))
+        {
+            for (size_t i = 0; i < m_jointsInDeg.size(); ++i)
+            {
+                jointValuesInRad(i) = iDynTree::deg2rad(m_jointsInDeg(i));
+            }
+        }
+    }
+    return true;
+}
+
+void RemapperConnector::close()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_robotDevice.close();
+    m_encodersInterface = nullptr;
+}
+
+}

--- a/src/modules/idyntree-yarp-visualizer/RobotConnectors.cpp
+++ b/src/modules/idyntree-yarp-visualizer/RobotConnectors.cpp
@@ -388,12 +388,12 @@ bool StateExtConnector::configure(const yarp::os::Searchable &inputConf, std::sh
         }
         else if (robotLocalName == "icub")
         {
-            confValue.fromString("(head, (neck_pitch, neck_roll, neck_yaw),"
-                                 " torso, (torso_yaw, torso_pitch, torso_roll),"
+            confValue.fromString("((head, 3), (neck_pitch, neck_roll, neck_yaw, eyes_tilt, eyes_vers, eyes_verg),"
+                                 " torso, (torso_roll, torso_pitch, torso_yaw),"
                                  " (left_arm, 7), (l_shoulder_pitch, l_shoulder_roll, l_shoulder_yaw, l_elbow, l_wrist_prosup, l_wrist_pitch, l_wrist_yaw,"
-                                                  "l_thumb_oppose, l_thumb_proximal, l_thumb_distal, l_index_proximal, l_index-distal, l_middle-proximal, l_middle-distal, l_little-fingers),"
-                                 " (right_arm, 7), (r_shoulder_pitch, r_shoulder_roll, r_shoulder_yaw, r_elbow, r_wrist_prosup, r_wrist_pitch, r_wrist_yaw),"
-                                                   "r_thumb_oppose, r_thumb_proximal, r_thumb_distal, r_index_proximal, r_index-distal, r_middle-proximal, r_middle-distal, r_little-fingers),"
+                                    " l_hand_finger, l_thumb_oppose, l_thumb_proximal, l_thumb_distal, l_index_proximal, l_index_distal, l_middle_proximal, l_middle_distal, l_little_fingers),"
+                                 " (right_arm, 7), (r_shoulder_pitch, r_shoulder_roll, r_shoulder_yaw, r_elbow, r_wrist_prosup, r_wrist_pitch, r_wrist_yaw,"
+                                    " r_hand_finger, r_thumb_oppose, r_thumb_proximal, r_thumb_distal, r_index_proximal, r_index_distal, r_middle_proximal, r_middle_distal, r_little_fingers),"
                                  " left_leg, (l_hip_pitch, l_hip_roll, l_hip_yaw, l_knee, l_ankle_pitch, l_ankle_roll),"
                                  " right_leg, (r_hip_pitch, r_hip_roll, r_hip_yaw, r_knee, r_ankle_pitch, r_ankle_roll))");
         }
@@ -548,8 +548,11 @@ void StateExtConnector::close()
 
 StateExtConnector::EncodersInterface::~EncodersInterface()
 {
-    device->close();
-    delete device;
+    if (device)
+    {
+        device->close();
+        delete device;
+    }
 }
 
 }

--- a/src/modules/idyntree-yarp-visualizer/RobotConnectors.cpp
+++ b/src/modules/idyntree-yarp-visualizer/RobotConnectors.cpp
@@ -4,7 +4,7 @@
 
 namespace idyntree_yarp_tools {
 
-bool RemapperConnector::getorGuessControlBoardsFromFile(const yarp::os::Searchable &inputConf)
+bool RemapperConnector::getOrGuessControlBoardsFromFile(const yarp::os::Searchable &inputConf)
 {
     m_controlBoards.clear();
     yarp::os::Value controlBoardsValue = inputConf.find("controlboards");
@@ -38,21 +38,75 @@ bool RemapperConnector::getorGuessControlBoardsFromFile(const yarp::os::Searchab
     return true;
 }
 
-bool RemapperConnector::configure(const yarp::os::Searchable &inputConf, std::shared_ptr<BasicInfo> basicInfo)
+bool RemapperConnector::getJointNamesFromModel(const yarp::os::Searchable &inputConf, const iDynTree::Model &model)
+{
+    std::lock_guard<std::mutex> lock(m_basicInfo->mutex);
+
+    m_basicInfo->jointList.clear();
+
+    yarp::os::Value jointsValue = inputConf.find("joints");
+
+    if (jointsValue.isNull())
+    {
+        for (size_t i = 0; i < model.getNrOfJoints(); ++i)
+        {
+            if (model.getJoint(i)->getNrOfDOFs() == 1)
+            {
+                m_basicInfo->jointList.push_back(model.getJointName(i)); //automatically select all the joint in the model that have 1DOF
+            }
+        }
+        if (m_basicInfo->jointList.size() != model.getNrOfPosCoords())
+        {
+            yError() << "The model contains joints with more than 1DOF. This is not yet supported.";
+            return false;
+        }
+    }
+    else
+    {
+        if (!jointsValue.isList())
+        {
+            yError() << "joints is specified, but it is not a list.";
+            return false;
+        }
+
+        yarp::os::Bottle* jointList = jointsValue.asList();
+
+        for (size_t i = 0; i < jointList->size(); ++i)
+        {
+            yarp::os::Value jvalue = jointList->get(i);
+            if (!jvalue.isString())
+            {
+                yError() << "The value in position " << i << " (0-based) of joints is not a string.";
+                return false;
+            }
+            m_basicInfo->jointList.push_back(jvalue.asString());
+        }
+    }
+
+    m_jointsInDeg.resize(m_basicInfo->jointList.size());
+    m_jointsInDeg.zero();
+
+    return true;
+}
+
+bool RemapperConnector::configure(const yarp::os::Searchable &inputConf, const iDynTree::Model &fullModel, std::shared_ptr<BasicInfo> basicInfo)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
-
-    if (!getorGuessControlBoardsFromFile(inputConf))
     {
+        std::lock_guard<std::mutex>(basicInfo->mutex);
+        m_basicInfo = basicInfo;
+    }
+
+    if (!getOrGuessControlBoardsFromFile(inputConf))
+    {
+        yError() << "Failed to get the controlboards list.";
         return false;
     }
 
-    m_basicInfo = basicInfo;
-
+    if (!getJointNamesFromModel(inputConf, fullModel))
     {
-        std::lock_guard<std::mutex>(m_basicInfo->mutex);
-
-        m_jointsInDeg.resize(m_basicInfo->jointList.size());
+        yError() << "Failed to get the list of joints.";
+        return false;
     }
 
     return true;
@@ -122,6 +176,89 @@ bool RemapperConnector::getJointValues(iDynTree::VectorDynSize &jointValuesInRad
 }
 
 void RemapperConnector::close()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_robotDevice.close();
+    m_encodersInterface = nullptr;
+}
+
+bool StateExtConnector::getAxesDescription(const yarp::os::Value &inputValue)
+{
+    m_cb_jointsMap.clear();
+
+    if (!inputValue.isList())
+    {
+        yError() << "connectToStateExt is specified, but the input is not a list.";
+        return false;
+    }
+
+    yarp::os::Bottle* cbJointList = inputValue.asList();
+
+    if (cbJointList->size() %2 != 0)
+    {
+        yError() << "The list provided after connectToStateExt is supposed to have an even number of elements. It is supposed to be a sequence of a string (the name of the control board), followed by the list of joints in the control board.";
+        return false;
+    }
+
+    for (size_t i = 0; i < cbJointList->size(); i += 2)
+    {
+        yarp::os::Value& cbName = cbJointList->get(i);
+        if (!cbName.isString())
+        {
+            yError() << "The element in position " << i << " (0-based) of the connectToStateExt list is supposed to be a string, namely the name of the control board.";
+            return false;
+        }
+
+        yarp::os::Value& jointList = cbJointList->get(i+1);
+        if (!jointList.isList())
+        {
+            yError() << "The element in position " << i+1 << " (0-based) of the connectToStateExt list is supposed to be a list, namely the list of joints of the specific control board.";
+            return false;
+        }
+
+        std::vector<std::string>& jointVector = m_cb_jointsMap[cbName.asString()];
+
+
+
+    }
+
+    return true;
+}
+
+bool StateExtConnector::configure(const yarp::os::Searchable &inputConf, std::shared_ptr<BasicInfo> basicInfo)
+{
+
+    return true;
+}
+
+bool StateExtConnector::usingStateExt(const yarp::os::Searchable &inputConf)
+{
+    return inputConf.check("connectToStateExt");
+}
+
+bool StateExtConnector::connectToRobot()
+{
+    return true;
+}
+
+bool StateExtConnector::getJointValues(iDynTree::VectorDynSize &jointValuesInRad)
+{
+    if (m_connected)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+
+        if (m_encodersInterface->getEncoders(m_jointsInDeg.data()))
+        {
+            for (size_t i = 0; i < m_jointsInDeg.size(); ++i)
+            {
+                jointValuesInRad(i) = iDynTree::deg2rad(m_jointsInDeg(i));
+            }
+        }
+    }
+    return true;
+}
+
+void StateExtConnector::close()
 {
     std::lock_guard<std::mutex> lock(m_mutex);
     m_robotDevice.close();

--- a/src/modules/idyntree-yarp-visualizer/RobotConnectors.cpp
+++ b/src/modules/idyntree-yarp-visualizer/RobotConnectors.cpp
@@ -366,7 +366,45 @@ bool StateExtConnector::configure(const yarp::os::Searchable &inputConf, std::sh
 
     m_basicInfo = basicInfo;
 
-    if (!getAxesDescription(inputConf.find("connectToStateExt")))
+    yarp::os::Value confValue = inputConf.find("connectToStateExt");
+
+    if (confValue.isString() && confValue.asString() == "default")
+    {
+        std::string robotLocalName;
+        {
+            std::lock_guard<std::mutex> lock(m_basicInfo->mutex);
+
+            robotLocalName = m_basicInfo->robotPrefix;
+        }
+
+        if (robotLocalName == "icubSim")
+        {
+            confValue.fromString("(head, (neck_pitch, neck_roll, neck_yaw),"
+                                 " torso, (torso_yaw, torso_pitch, torso_roll),"
+                                 " left_arm, (l_shoulder_pitch, l_shoulder_roll, l_shoulder_yaw, l_elbow, l_wrist_prosup, l_wrist_pitch, l_wrist_yaw),"
+                                 " right_arm, (r_shoulder_pitch, r_shoulder_roll, r_shoulder_yaw, r_elbow, r_wrist_prosup, r_wrist_pitch, r_wrist_yaw),"
+                                 " left_leg, (l_hip_pitch, l_hip_roll, l_hip_yaw, l_knee, l_ankle_pitch, l_ankle_roll),"
+                                 " right_leg, (r_hip_pitch, r_hip_roll, r_hip_yaw, r_knee, r_ankle_pitch, r_ankle_roll))");
+        }
+        else if (robotLocalName == "icub")
+        {
+            confValue.fromString("(head, (neck_pitch, neck_roll, neck_yaw),"
+                                 " torso, (torso_yaw, torso_pitch, torso_roll),"
+                                 " (left_arm, 7), (l_shoulder_pitch, l_shoulder_roll, l_shoulder_yaw, l_elbow, l_wrist_prosup, l_wrist_pitch, l_wrist_yaw,"
+                                                  "l_thumb_oppose, l_thumb_proximal, l_thumb_distal, l_index_proximal, l_index-distal, l_middle-proximal, l_middle-distal, l_little-fingers),"
+                                 " (right_arm, 7), (r_shoulder_pitch, r_shoulder_roll, r_shoulder_yaw, r_elbow, r_wrist_prosup, r_wrist_pitch, r_wrist_yaw),"
+                                                   "r_thumb_oppose, r_thumb_proximal, r_thumb_distal, r_index_proximal, r_index-distal, r_middle-proximal, r_middle-distal, r_little-fingers),"
+                                 " left_leg, (l_hip_pitch, l_hip_roll, l_hip_yaw, l_knee, l_ankle_pitch, l_ankle_roll),"
+                                 " right_leg, (r_hip_pitch, r_hip_roll, r_hip_yaw, r_knee, r_ankle_pitch, r_ankle_roll))");
+        }
+        else
+        {
+            yError() << "No default connectToStateExt configuration for the robot" << robotLocalName;
+            return false;
+        }
+    }
+
+    if (!getAxesDescription(confValue))
     {
         yError() << "Failed to read the connectToStateExt parameter.";
         return false;

--- a/src/modules/idyntree-yarp-visualizer/RobotConnectors.cpp
+++ b/src/modules/idyntree-yarp-visualizer/RobotConnectors.cpp
@@ -203,7 +203,7 @@ bool StateExtConnector::getAxesDescription(const yarp::os::Value &inputValue)
     if (cbJointList->size() %2 != 0)
     {
         yError() << "The list provided after connectToStateExt is supposed to have an even number of elements."
-                 << "It needs to be a sequence of a list containing the name of the control board (and eventuually the number of joints to consider),"
+                 << "It needs to be a sequence of a list containing the name of the control board (and eventually the number of joints to consider),"
                      "followed by the full list of joints in the control board.";
         return false;
     }

--- a/src/modules/idyntree-yarp-visualizer/RobotConnectors.cpp
+++ b/src/modules/idyntree-yarp-visualizer/RobotConnectors.cpp
@@ -4,6 +4,8 @@
 #include "RobotConnectors.h"
 #include <algorithm>
 
+YARP_DECLARE_PLUGINS(ReadOnlyRemoteControlBoardLib);
+
 namespace idyntree_yarp_tools {
 
 bool RemapperConnector::getOrGuessControlBoardsFromFile(const yarp::os::Searchable &inputConf)
@@ -383,6 +385,8 @@ bool StateExtConnector::connectToRobot()
     m_connected = false;
     {
         std::lock_guard<std::mutex> lock(m_mutex);
+
+        YARP_REGISTER_PLUGINS(ReadOnlyRemoteControlBoardLib);
 
         std::string localRobotName, localName;
         {

--- a/src/modules/idyntree-yarp-visualizer/RobotConnectors.h
+++ b/src/modules/idyntree-yarp-visualizer/RobotConnectors.h
@@ -4,10 +4,12 @@
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/IEncodersTimed.h>
 #include <iDynTree/Core/VectorDynSize.h>
+#include <iDynTree/Model/Model.h>
 #include <mutex>
 #include <atomic>
 #include <vector>
 #include <string>
+#include <map>
 #include <memory>
 
 
@@ -35,11 +37,39 @@ class RemapperConnector
     std::shared_ptr<BasicInfo> m_basicInfo;
     std::mutex m_mutex;
 
-    bool getorGuessControlBoardsFromFile(const yarp::os::Searchable &inputConf);
+    bool getOrGuessControlBoardsFromFile(const yarp::os::Searchable &inputConf);
+
+    bool getJointNamesFromModel(const yarp::os::Searchable &inputConf, const iDynTree::Model& model);
+
+
+public:
+
+    bool configure(const yarp::os::Searchable &inputConf, const iDynTree::Model& fullModel, std::shared_ptr<BasicInfo> basicInfo);
+
+    bool connectToRobot();
+
+    bool getJointValues(iDynTree::VectorDynSize& jointValuesInRad);
+
+    void close();
+};
+
+class StateExtConnector
+{
+    std::map<std::string, std::vector<std::string>> m_cb_jointsMap;
+    yarp::dev::PolyDriver m_robotDevice;
+    yarp::dev::IEncodersTimed *m_encodersInterface{nullptr};
+    std::atomic<bool> m_connected{false};
+    iDynTree::VectorDynSize m_jointsInDeg;
+    std::shared_ptr<BasicInfo> m_basicInfo;
+    std::mutex m_mutex;
+
+    bool getAxesDescription(const yarp::os::Value &inputValue);
 
 public:
 
     bool configure(const yarp::os::Searchable &inputConf, std::shared_ptr<BasicInfo> basicInfo);
+
+    bool usingStateExt(const yarp::os::Searchable &inputConf);
 
     bool connectToRobot();
 

--- a/src/modules/idyntree-yarp-visualizer/RobotConnectors.h
+++ b/src/modules/idyntree-yarp-visualizer/RobotConnectors.h
@@ -55,7 +55,19 @@ public:
 
 class StateExtConnector
 {
-    std::map<std::string, std::vector<std::string>> m_cb_jointsMap;
+    enum class JointType
+    {
+        REVOLUTE,
+        PRISMATIC
+    };
+
+    struct JointInfo
+    {
+        std::string name;
+        JointType type;
+    };
+
+    std::vector<std::pair<std::string, std::vector<JointInfo>>> m_cb_jointsMap;
     yarp::dev::PolyDriver m_robotDevice;
     yarp::dev::IEncodersTimed *m_encodersInterface{nullptr};
     std::atomic<bool> m_connected{false};

--- a/src/modules/idyntree-yarp-visualizer/RobotConnectors.h
+++ b/src/modules/idyntree-yarp-visualizer/RobotConnectors.h
@@ -67,11 +67,18 @@ class StateExtConnector
         JointType type;
     };
 
+    struct EncodersInterface
+    {
+        yarp::dev::PolyDriver* device;
+        yarp::dev::IEncodersTimed* encoders{nullptr};
+        iDynTree::VectorDynSize jointsBuffer;
+
+        ~EncodersInterface();
+    };
+
     std::vector<std::pair<std::string, std::vector<JointInfo>>> m_cb_jointsMap;
-    yarp::dev::PolyDriver m_robotDevice;
-    yarp::dev::IEncodersTimed *m_encodersInterface{nullptr};
+    std::vector<EncodersInterface> m_encodersInterfaces;
     std::atomic<bool> m_connected{false};
-    iDynTree::VectorDynSize m_jointsInDeg;
     std::shared_ptr<BasicInfo> m_basicInfo;
     std::mutex m_mutex;
 

--- a/src/modules/idyntree-yarp-visualizer/RobotConnectors.h
+++ b/src/modules/idyntree-yarp-visualizer/RobotConnectors.h
@@ -76,7 +76,7 @@ class StateExtConnector
 
     struct EncodersInterface
     {
-        yarp::dev::PolyDriver* device;
+        yarp::dev::PolyDriver* device{nullptr};
         yarp::dev::IEncodersTimed* encoders{nullptr};
         iDynTree::VectorDynSize jointsBuffer;
         size_t jointsToConsider;

--- a/src/modules/idyntree-yarp-visualizer/RobotConnectors.h
+++ b/src/modules/idyntree-yarp-visualizer/RobotConnectors.h
@@ -67,16 +67,24 @@ class StateExtConnector
         JointType type;
     };
 
+    struct ControlBoardInfo
+    {
+        std::string name;
+        int jointsToConsider;
+        std::vector<JointInfo> joints;
+    };
+
     struct EncodersInterface
     {
         yarp::dev::PolyDriver* device;
         yarp::dev::IEncodersTimed* encoders{nullptr};
         iDynTree::VectorDynSize jointsBuffer;
+        size_t jointsToConsider;
 
         ~EncodersInterface();
     };
 
-    std::vector<std::pair<std::string, std::vector<JointInfo>>> m_cb_jointsMap;
+    std::vector<ControlBoardInfo> m_cb_jointsMap;
     std::vector<EncodersInterface> m_encodersInterfaces;
     std::atomic<bool> m_connected{false};
     std::shared_ptr<BasicInfo> m_basicInfo;

--- a/src/modules/idyntree-yarp-visualizer/RobotConnectors.h
+++ b/src/modules/idyntree-yarp-visualizer/RobotConnectors.h
@@ -1,0 +1,55 @@
+#ifndef  IDYNTREE_YARP_ROBOTCONNECTORS_H
+#define  IDYNTREE_YARP_ROBOTCONNECTORS_H
+
+#include <yarp/dev/PolyDriver.h>
+#include <yarp/dev/IEncodersTimed.h>
+#include <iDynTree/Core/VectorDynSize.h>
+#include <mutex>
+#include <atomic>
+#include <vector>
+#include <string>
+#include <memory>
+
+
+namespace idyntree_yarp_tools {
+
+struct BasicInfo
+{
+    std::string name;
+
+    std::vector<std::string> jointList;
+
+    std::string robotPrefix;
+
+    std::mutex mutex;
+};
+
+class RemapperConnector
+{
+
+    std::vector<std::string> m_controlBoards;
+    yarp::dev::PolyDriver m_robotDevice;
+    yarp::dev::IEncodersTimed *m_encodersInterface{nullptr};
+    std::atomic<bool> m_connected{false};
+    iDynTree::VectorDynSize m_jointsInDeg;
+    std::shared_ptr<BasicInfo> m_basicInfo;
+    std::mutex m_mutex;
+
+    bool getorGuessControlBoardsFromFile(const yarp::os::Searchable &inputConf);
+
+public:
+
+    bool configure(const yarp::os::Searchable &inputConf, std::shared_ptr<BasicInfo> basicInfo);
+
+    bool connectToRobot();
+
+    bool getJointValues(iDynTree::VectorDynSize& jointValuesInRad);
+
+    void close();
+};
+
+
+}
+
+
+#endif //  IDYNTREE_YARP_ROBOTCONNECTORS_H

--- a/src/modules/idyntree-yarp-visualizer/Visualizer.cpp
+++ b/src/modules/idyntree-yarp-visualizer/Visualizer.cpp
@@ -670,7 +670,6 @@ void idyntree_yarp_tools::Visualizer::close()
     std::lock_guard<std::mutex> lock(m_mutex);
 
     m_viz.close();
-    m_image.resize(0,0);
     m_imagePort.close();
     m_rpcPort.close();
     m_remapperConnector.close();

--- a/src/modules/idyntree-yarp-visualizer/Visualizer.cpp
+++ b/src/modules/idyntree-yarp-visualizer/Visualizer.cpp
@@ -520,34 +520,54 @@ bool idyntree_yarp_tools::Visualizer::neededHelp(const yarp::os::ResourceFinder 
     {
         std::cout << "Usage: idyntree-yarp-visualizer" << std::endl
                   << "Optional arguments:" << std::endl
-                  << "--name <name>                                      The prefix used to open the visualizer ports. Default: idyntree-yarp-visualizer;" << std::endl
-                  << "--robot <robot>                                    The prefix used to connect to the robot. Default: icub;" << std::endl
-                  << "--model <model>                                    The URDF model to open. Default: model.urdf, it will be found according to the YARP_ROBOT_NAME;" << std::endl
-                  << "--offline                                          Avoid to use the network. The model is only visualized;" << std::endl
+                  << "--name <name>                                      The prefix used to open the visualizer ports. Default: idyntree-yarp-visualizer;" << std::endl << std::endl
+                  << "--robot <robot>                                    The prefix used to connect to the robot. Default: icub;" << std::endl << std::endl
+                  << "--model <model>                                    The URDF model to open. Default: model.urdf, it will be found according to the YARP_ROBOT_NAME;" << std::endl << std::endl
+                  << "--offline                                          Avoid to use the network. The model is only visualized;" << std::endl << std::endl
                   << "--autoconnect [true|false]                         If set to true, or no value is provided, it will try to connect to the robot automatically at startup." << std::endl
-                  << "                                                   If fails, the visualizer does not start. By default it tries to connect to the robot, but if it fails, nothing happens;" << std::endl
-                  << "--controlboards \"(<cb1>, ...)\"                     The set of control boards to connect to. Default: \"(head, torso, left_arm, right_arm, left_leg, right_leg)\";" << std::endl
+                  << "                                                   If fails, the visualizer does not start. By default it tries to connect to the robot, but if it fails, nothing happens;" << std::endl << std::endl
+                  << "--controlboards \"(<cb1>, ...)\"                     The set of control boards to connect to. Default: \"(head, torso, left_arm, right_arm, left_leg, right_leg)\";" << std::endl << std::endl
                   << "--joints \"(<j1>, ...)\"                             The set of joints to consider. These names are used both in the model and when connecting to the robot." << std::endl
-                  << "                                                   By default, it uses all the joints specified in the model having one degree of freedom;" << std::endl
-                  << "--cameraPosition \"(px, py, pz)\"                    Camera initial position. Default \"(0.8, 0.8, 0.8)\";" << std::endl
-                  << "--imageWidth <width>                               The initial width of the visualizer window. Default 800;" << std::endl
-                  << "--imageHeight <height>                             The initial height of the visualizer window. Default 600;" << std::endl
-                  << "--maxFPS <fps>                                     The maximum frame per seconds to update the visualizer. Default 65;" << std::endl
-                  << "--backgroundColor \"(r, g, b)\"                      Visualizer background color. Default \"(0.0, 0.4, 0.4)\";" << std::endl
-                  << "--floorGridColor \"(r, g, b)\"                       Visualizer floor grid color. Default \"(0.0, 0.0, 1.0)\";" << std::endl
-                  << "--floorVisible <true|false>                        Set the visibility of the visualizer floor grid. Default true;" << std::endl
-                  << "--worldFrameVisible <true|false>                   Set the visibility of the visualizer world frame. Default true;" << std::endl
-                  << "--streamImage <true|false>                         If set to true, the visualizer can publish on a port what is rendered in the visualizer. Default true;" << std::endl << std::endl
-                  << " The following optional arguments are used only if the streaming of the image is enabled (see --streamImage):" << std::endl
-                  << "--OUTPUT_STREAM::portName <name>                   The suffix of the port where the stream the image. Default \"image\";" <<std::endl
-                  << "--OUTPUT_STREAM::imageWidth <width>                The width of the image streamed on the port. Default 400;" <<std::endl
-                  << "--OUTPUT_STREAM::imageHeight <height>              The height of the image streamed on the port. Default 400;" <<std::endl
-                  << "--OUTPUT_STREAM::maxFPS <fps>                      The maximum number of times per second the image is streamed on the network. Default 30;" <<std::endl
-                  << "--OUTPUT_STREAM::mirrorImage <true|false>          If true, it mirrors the image before streaming it. Default false;" <<std::endl
-                  << "--OUTPUT_STREAM::floorVisible <true|false>         Set the visibility of the floor grid in the streamed image. Default false;" <<std::endl
-                  << "--OUTPUT_STREAM::worldFrameVisible <true|false>    Set the visibility of the world frame in the streamed image. Default false;" <<std::endl
-                  << "--OUTPUT_STREAM::backgroundColor \"(r, g, b)\"       Set the background color of the streamed image. Default \"(0.0, 0.0, 0.0)\";" << std::endl
-                  << "--OUTPUT_STREAM::floorGridColor \"(r, g, b)\"        Set the floor grid color of the streamed image. Default \"(0.0, 0.0, 1.0)\";" << std::endl << std::endl
+                  << "                                                   By default, it uses all the joints specified in the model having one degree of freedom;" << std::endl << std::endl
+                  << "--connectToStateExt \"(<cb1>, (<j1>, ...), ..)\"     With this command, it is possible to connect to the stateExt ports opened by the robot. This allows to visualize also data" << std::endl
+                  << "                                                   saved through the yarpdatatdumper for example. The stateExt ports contain only joint values, without any other information," << std::endl
+                  << "                                                   hence, it is necessary to explicitly list all the joints of the selected control boards in their correct order. " << std::endl
+                  << "                                                   The list provided after connectToStateExt is supposed to have an even number of elements." << std::endl
+                  << "                                                   It needs to be a sequence of a list containing the name of the control board (and eventually the number of joints to consider)," << std::endl
+                  << "                                                   followed by the full list of joints in the control board. Each joint entry can also be a list. In this case," << std::endl
+                  << "                                                   the first element is the joint name, the second is a keyword for the " << std::endl
+                  << "                                                   joint type (\"p\" or \"prismatic\" for prismatic joints, \"r\" or \"revolute\" for revolute joints)." << std::endl
+                  << "                                                   If a joint name is specified without being a list, then it is assumed to be a revolute joint."  << std::endl
+                  << "                                                   For example, suppose you want to connect to the neck and the torso, the syntax would be:"  << std::endl
+                  << "                                                   --connectToStateExt \"(head, (neck_pitch, neck_roll, neck_yaw), torso, (torso_pitch, torso_roll, torso_yaw)\"" << std::endl
+                  << "                                                   If, for example, neck_roll is a prismatic joint, the syntax would be:" << std::endl
+                  << "                                                   --connectToStateExt \"(head, (neck_pitch, (neck_roll, p), neck_yaw), torso, (torso_pitch, torso_roll, torso_yaw)\"" << std::endl
+                  << "                                                   In some case, it might be useful to consider only the first n joints of a control board (for example to avoid considering the hand joints)." << std::endl
+                  << "                                                   It is still necessary to specify all the joints, but only the first n will be used for the visualization." << std::endl
+                  << "                                                   For example, if you want to avoid considering the torso_yaw in the visualization, use the following notation:" << std::endl
+                  << "                                                   --connectToStateExt \"(head, (neck_pitch, (neck_roll, p), neck_yaw), (torso, 2), (torso_pitch, torso_roll, torso_yaw)\"" << std::endl
+                  << "                                                   In case --robot is \"icub\" or \"icubSim\" it is possible to use the following simplified syntax to connect to all the supported joints:" << std::endl
+                  << "                                                   --connectToStateExt default" << std::endl
+                  << "                                                   When using connectToStateExt, the --controlboards and --joints options are ignored." << std::endl << std::endl
+                  << "--cameraPosition \"(px, py, pz)\"                    Camera initial position. Default \"(0.8, 0.8, 0.8)\";" << std::endl << std::endl
+                  << "--imageWidth <width>                               The initial width of the visualizer window. Default 800;" << std::endl << std::endl
+                  << "--imageHeight <height>                             The initial height of the visualizer window. Default 600;" << std::endl << std::endl
+                  << "--maxFPS <fps>                                     The maximum frame per seconds to update the visualizer. Default 65;" << std::endl << std::endl
+                  << "--backgroundColor \"(r, g, b)\"                      Visualizer background color. Default \"(0.0, 0.4, 0.4)\";" << std::endl << std::endl
+                  << "--floorGridColor \"(r, g, b)\"                       Visualizer floor grid color. Default \"(0.0, 0.0, 1.0)\";" << std::endl << std::endl
+                  << "--floorVisible <true|false>                        Set the visibility of the visualizer floor grid. Default true;" << std::endl << std::endl
+                  << "--worldFrameVisible <true|false>                   Set the visibility of the visualizer world frame. Default true;" << std::endl << std::endl
+                  << "--streamImage <true|false>                         If set to true, the visualizer can publish on a port what is rendered in the visualizer. Default true;" << std::endl << std::endl << std::endl
+                  << " The following optional arguments are used only if the streaming of the image is enabled (see --streamImage):" << std::endl << std::endl
+                  << "--OUTPUT_STREAM::portName <name>                   The suffix of the port where the stream the image. Default \"image\";" <<std::endl << std::endl
+                  << "--OUTPUT_STREAM::imageWidth <width>                The width of the image streamed on the port. Default 400;" <<std::endl << std::endl
+                  << "--OUTPUT_STREAM::imageHeight <height>              The height of the image streamed on the port. Default 400;" <<std::endl << std::endl
+                  << "--OUTPUT_STREAM::maxFPS <fps>                      The maximum number of times per second the image is streamed on the network. Default 30;" <<std::endl << std::endl
+                  << "--OUTPUT_STREAM::mirrorImage <true|false>          If true, it mirrors the image before streaming it. Default false;" <<std::endl << std::endl
+                  << "--OUTPUT_STREAM::floorVisible <true|false>         Set the visibility of the floor grid in the streamed image. Default false;" <<std::endl << std::endl
+                  << "--OUTPUT_STREAM::worldFrameVisible <true|false>    Set the visibility of the world frame in the streamed image. Default false;" <<std::endl << std::endl
+                  << "--OUTPUT_STREAM::backgroundColor \"(r, g, b)\"       Set the background color of the streamed image. Default \"(0.0, 0.0, 0.0)\";" << std::endl << std::endl
+                  << "--OUTPUT_STREAM::floorGridColor \"(r, g, b)\"        Set the floor grid color of the streamed image. Default \"(0.0, 0.0, 1.0)\";" << std::endl << std::endl << std::endl
                   << "All these options can be added to a .ini file. If you use the following argument:" << std::endl
                   << "--from </path/file>.ini                            Example of .ini file:" << std::endl
                   << "                                                   #--------------------"<< std::endl
@@ -559,7 +579,7 @@ bool idyntree_yarp_tools::Visualizer::neededHelp(const yarp::os::ResourceFinder 
                   << "                                                   floorGridColor (1.0, 0.0, 0.0)" << std::endl
                   << "                                                   #--------------------" <<std::endl
                   << "                                                   Note that all the -- have been removed, while the prefix OUTPUT_STREAM::" <<std::endl
-                  << "                                                   is no more necessary after the [OUTPUT_STREAM] tag." <<std::endl;
+                  << "                                                   is no more necessary after the [OUTPUT_STREAM] tag." <<std::endl << std::endl;
 
         return true;
     }

--- a/src/modules/idyntree-yarp-visualizer/Visualizer.cpp
+++ b/src/modules/idyntree-yarp-visualizer/Visualizer.cpp
@@ -589,7 +589,18 @@ bool idyntree_yarp_tools::Visualizer::neededHelp(const yarp::os::ResourceFinder 
                   << "--OUTPUT_STREAM::floorVisible <true|false>         Set the visibility of the floor grid in the streamed image. Default false;" <<std::endl
                   << "--OUTPUT_STREAM::worldFrameVisible <true|false>    Set the visibility of the world frame in the streamed image. Default false;" <<std::endl
                   << "--OUTPUT_STREAM::backgroundColor <(r, g, b)>       Set the background color of the streamed image. Default (0.0, 0.0, 0.0);" << std::endl
-                  << "--OUTPUT_STREAM::floorGridColor <(r, g, b)>        Set the floor grid color of the streamed image. Default (0.0, 0.0, 1.0);" << std::endl;
+                  << "--OUTPUT_STREAM::floorGridColor <(r, g, b)>        Set the floor grid color of the streamed image. Default (0.0, 0.0, 1.0);" << std::endl << std::endl
+                  << "All these options can be added to a .ini file. If you use the following argument:" << std::endl
+                  << "--from </path/file>.ini                            Example of .ini file:" << std::endl
+                  << "                                                   #--------------------"<< std::endl
+                  << "                                                   name    anotherName" << std::endl
+                  << "                                                   robot   myRobot" << std::endl
+                  << "                                                   [OUTPUT_STREAM]" <<std::endl
+                  << "                                                   portName    myPort" << std::endl
+                  << "                                                   mirrorImage true" << std::endl
+                  << "                                                   #--------------------" <<std::endl
+                  << "                                                   Note that all the -- have been removed, while the prefix OUTPUT_STREAM::" <<std::endl
+                  << "                                                   is no more necessary after the [OUTPUT_STREAM] tag." <<std::endl;
 
         return true;
     }

--- a/src/modules/idyntree-yarp-visualizer/Visualizer.cpp
+++ b/src/modules/idyntree-yarp-visualizer/Visualizer.cpp
@@ -518,15 +518,15 @@ bool idyntree_yarp_tools::Visualizer::neededHelp(const yarp::os::ResourceFinder 
                   << "--offline                                          Avoid to use the network. The model is only visualized;" << std::endl
                   << "--autoconnect [true|false]                         If set to true, or no value is provided, it will try to connect to the robot automatically at startup." << std::endl
                   << "                                                   If fails, the visualizer does not start. By default it tries to connect to the robot, but if it fails, nothing happens;" << std::endl
-                  << "--controlboards <(\"cb1\", ...)>                     The set of control boards to connect to. Default: (\"head\", \"torso\", \"left_arm\", \"right_arm\", \"left_leg\", \"right_leg\");" << std::endl
-                  << "--joints <(\"j1\", ...)>                             The set of joints to consider. These names are used both in the model and when connecting to the robot." << std::endl
+                  << "--controlboards \"(<cb1>, ...)\"                     The set of control boards to connect to. Default: \"(head, torso, left_arm, right_arm, left_leg, right_leg)\";" << std::endl
+                  << "--joints \"(<j1>, ...)\"                             The set of joints to consider. These names are used both in the model and when connecting to the robot." << std::endl
                   << "                                                   By default, it uses all the joints specified in the model having one degree of freedom;" << std::endl
-                  << "--cameraPosition <(px, py, pz)>                    Camera initial position. Default (0.8, 0.8, 0.8);" << std::endl
+                  << "--cameraPosition \"(px, py, pz)\"                    Camera initial position. Default \"(0.8, 0.8, 0.8)\";" << std::endl
                   << "--imageWidth <width>                               The initial width of the visualizer window. Default 800;" << std::endl
                   << "--imageHeight <height>                             The initial height of the visualizer window. Default 600;" << std::endl
                   << "--maxFPS <fps>                                     The maximum frame per seconds to update the visualizer. Default 65;" << std::endl
-                  << "--backgroundColor <(r, g, b)>                      Visualizer background color. Default (0.0, 0.4, 0.4);" << std::endl
-                  << "--floorGridColor <(r, g, b)>                       Visualizer floor grid color. Default (0.0, 0.0, 1.0);" << std::endl
+                  << "--backgroundColor \"(r, g, b)\"                      Visualizer background color. Default \"(0.0, 0.4, 0.4)\";" << std::endl
+                  << "--floorGridColor \"(r, g, b)\"                       Visualizer floor grid color. Default \"(0.0, 0.0, 1.0)\";" << std::endl
                   << "--floorVisible <true|false>                        Set the visibility of the visualizer floor grid. Default true;" << std::endl
                   << "--worldFrameVisible <true|false>                   Set the visibility of the visualizer world frame. Default true;" << std::endl
                   << "--streamImage <true|false>                         If set to true, the visualizer can publish on a port what is rendered in the visualizer. Default true;" << std::endl << std::endl
@@ -538,8 +538,8 @@ bool idyntree_yarp_tools::Visualizer::neededHelp(const yarp::os::ResourceFinder 
                   << "--OUTPUT_STREAM::mirrorImage <true|false>          If true, it mirrors the image before streaming it. Default false;" <<std::endl
                   << "--OUTPUT_STREAM::floorVisible <true|false>         Set the visibility of the floor grid in the streamed image. Default false;" <<std::endl
                   << "--OUTPUT_STREAM::worldFrameVisible <true|false>    Set the visibility of the world frame in the streamed image. Default false;" <<std::endl
-                  << "--OUTPUT_STREAM::backgroundColor <(r, g, b)>       Set the background color of the streamed image. Default (0.0, 0.0, 0.0);" << std::endl
-                  << "--OUTPUT_STREAM::floorGridColor <(r, g, b)>        Set the floor grid color of the streamed image. Default (0.0, 0.0, 1.0);" << std::endl << std::endl
+                  << "--OUTPUT_STREAM::backgroundColor \"(r, g, b)\"       Set the background color of the streamed image. Default \"(0.0, 0.0, 0.0)\";" << std::endl
+                  << "--OUTPUT_STREAM::floorGridColor \"(r, g, b)\"        Set the floor grid color of the streamed image. Default \"(0.0, 0.0, 1.0)\";" << std::endl << std::endl
                   << "All these options can be added to a .ini file. If you use the following argument:" << std::endl
                   << "--from </path/file>.ini                            Example of .ini file:" << std::endl
                   << "                                                   #--------------------"<< std::endl
@@ -548,6 +548,7 @@ bool idyntree_yarp_tools::Visualizer::neededHelp(const yarp::os::ResourceFinder 
                   << "                                                   [OUTPUT_STREAM]" <<std::endl
                   << "                                                   portName    myPort" << std::endl
                   << "                                                   mirrorImage true" << std::endl
+                  << "                                                   floorGridColor (1.0, 0.0, 0.0)" << std::endl
                   << "                                                   #--------------------" <<std::endl
                   << "                                                   Note that all the -- have been removed, while the prefix OUTPUT_STREAM::" <<std::endl
                   << "                                                   is no more necessary after the [OUTPUT_STREAM] tag." <<std::endl;

--- a/src/modules/idyntree-yarp-visualizer/Visualizer.cpp
+++ b/src/modules/idyntree-yarp-visualizer/Visualizer.cpp
@@ -309,6 +309,13 @@ bool idyntree_yarp_tools::Visualizer::configure(const yarp::os::ResourceFinder &
     std::string modelName = rf.check("model", yarp::os::Value("model.urdf")).asString();
 
     std::string pathToModel = yarp::os::ResourceFinder::getResourceFinderSingleton().findFileByName(modelName);
+
+    if (pathToModel == "")
+    {
+        yError() << "Failed to find" << modelName;
+        return false;
+    }
+
     m_modelLoader.loadModelFromFile(pathToModel);
 
     std::string localName;
@@ -520,6 +527,7 @@ bool idyntree_yarp_tools::Visualizer::neededHelp(const yarp::os::ResourceFinder 
     {
         std::cout << "Usage: idyntree-yarp-visualizer" << std::endl
                   << "Optional arguments:" << std::endl
+                  << "--help                                             Print this message;" << std::endl << std::endl
                   << "--name <name>                                      The prefix used to open the visualizer ports. Default: idyntree-yarp-visualizer;" << std::endl << std::endl
                   << "--robot <robot>                                    The prefix used to connect to the robot. Default: icub;" << std::endl << std::endl
                   << "--model <model>                                    The URDF model to open. Default: model.urdf, it will be found according to the YARP_ROBOT_NAME;" << std::endl << std::endl
@@ -548,7 +556,7 @@ bool idyntree_yarp_tools::Visualizer::neededHelp(const yarp::os::ResourceFinder 
                   << "                                                   --connectToStateExt \"(head, (neck_pitch, (neck_roll, p), neck_yaw), (torso, 2), (torso_pitch, torso_roll, torso_yaw)\"" << std::endl
                   << "                                                   In case --robot is \"icub\" or \"icubSim\" it is possible to use the following simplified syntax to connect to all the supported joints:" << std::endl
                   << "                                                   --connectToStateExt default" << std::endl
-                  << "                                                   When using connectToStateExt, the --controlboards and --joints options are ignored." << std::endl << std::endl
+                  << "                                                   When using connectToStateExt, the --controlboards and --joints options are ignored;" << std::endl << std::endl
                   << "--cameraPosition \"(px, py, pz)\"                    Camera initial position. Default \"(0.8, 0.8, 0.8)\";" << std::endl << std::endl
                   << "--imageWidth <width>                               The initial width of the visualizer window. Default 800;" << std::endl << std::endl
                   << "--imageHeight <height>                             The initial height of the visualizer window. Default 600;" << std::endl << std::endl

--- a/src/modules/idyntree-yarp-visualizer/Visualizer.cpp
+++ b/src/modules/idyntree-yarp-visualizer/Visualizer.cpp
@@ -343,6 +343,14 @@ bool idyntree_yarp_tools::Visualizer::configure(const yarp::os::ResourceFinder &
 
     {
         std::lock_guard<std::mutex> lock(m_basicInfo->mutex);
+        std::stringstream jointListInfo;
+        jointListInfo << "Using the following joints for visualization:" << std::endl;
+        for (const std::string& joint : m_basicInfo->jointList)
+        {
+            jointListInfo << "    - " << joint <<std::endl;
+        }
+
+        yInfo() << jointListInfo.str();
 
         if (!m_modelLoader.loadReducedModelFromFullModel(m_modelLoader.model(), m_basicInfo->jointList)) //The connectors take care of setting the joint list
         {

--- a/src/modules/idyntree-yarp-visualizer/Visualizer.h
+++ b/src/modules/idyntree-yarp-visualizer/Visualizer.h
@@ -8,15 +8,15 @@
 #include <yarp/os/Network.h>
 #include <yarp/os/LogStream.h>
 #include <yarp/os/ResourceFinder.h>
-#include <yarp/dev/PolyDriver.h>
-#include <yarp/dev/IEncodersTimed.h>
 #include <cmath>
 #include <chrono>
 #include <thread>
 #include <atomic>
-#include <Utilities.h>
 #include <mutex>
 #include <thrifts/VisualizerCommands.h>
+#include <string>
+#include <Utilities.h>
+#include "RobotConnectors.h"
 
 
 namespace idyntree_yarp_tools {
@@ -24,16 +24,13 @@ namespace idyntree_yarp_tools {
 class Visualizer : public VisualizerCommands
 {
 
-    std::string m_name;
+    enum class ConnectionType
+    {
+        REMAPPER,
+        STATE_EXT
+    };
 
-    std::vector<std::string> m_jointList;
-
-    std::vector<std::string> m_controlBoards;
-
-    yarp::dev::PolyDriver m_robotDevice;
-    yarp::dev::IEncodersTimed *m_encodersInterface{nullptr};
-
-    std::string m_robotPrefix;
+    std::shared_ptr<BasicInfo> m_basicInfo;
 
     iDynTree::ModelLoader m_modelLoader;
 
@@ -56,11 +53,13 @@ class Visualizer : public VisualizerCommands
 
     iDynTree::Transform m_wHb;
     iDynTree::VectorDynSize m_joints;
-    iDynTree::VectorDynSize m_jointsInDeg;
 
     std::atomic<bool> m_isClosing{false};
     std::atomic<bool> m_connectedToTheRobot{false};
     std::atomic<bool> m_offline{false};
+
+    std::atomic<ConnectionType> m_connectionType{ConnectionType::REMAPPER};
+    RemapperConnector m_remapperConnector;
 
     yarp::os::Port m_rpcPort;
 
@@ -74,9 +73,12 @@ class Visualizer : public VisualizerCommands
 
     bool setVizCameraFromConfig(const yarp::os::Searchable &inputConf, iDynTree::ICamera& camera);
 
-    bool getOrGuessJointsAndBoards(const yarp::os::Searchable &inputConf, const iDynTree::Model& model);
+    bool getOrGuessBasicInfo(const yarp::os::Searchable &inputConf, const iDynTree::Model& model);
+
+    void updateJointValues();
 
 public:
+
     bool configure(const yarp::os::ResourceFinder& rf);
 
     bool neededHelp(const yarp::os::ResourceFinder& rf);

--- a/src/modules/idyntree-yarp-visualizer/Visualizer.h
+++ b/src/modules/idyntree-yarp-visualizer/Visualizer.h
@@ -60,6 +60,7 @@ class Visualizer : public VisualizerCommands
 
     std::atomic<ConnectionType> m_connectionType{ConnectionType::REMAPPER};
     RemapperConnector m_remapperConnector;
+    StateExtConnector m_stateExtConnector;
 
     yarp::os::Port m_rpcPort;
 
@@ -72,8 +73,6 @@ class Visualizer : public VisualizerCommands
     bool setVizEnvironmentFromConfig(const yarp::os::Searchable &inputConf, iDynTree::IEnvironment& environment);
 
     bool setVizCameraFromConfig(const yarp::os::Searchable &inputConf, iDynTree::ICamera& camera);
-
-    bool getOrGuessBasicInfo(const yarp::os::Searchable &inputConf, const iDynTree::Model& model);
 
     void updateJointValues();
 

--- a/src/modules/idyntree-yarp-visualizer/main.cpp
+++ b/src/modules/idyntree-yarp-visualizer/main.cpp
@@ -9,9 +9,12 @@
      */
 
 #include "Visualizer.h"
+YARP_DECLARE_PLUGINS(ReadOnlyRemoteControlBoardLib);
+
 
 int main(int argc, char * argv[])
 {
+    YARP_REGISTER_PLUGINS(ReadOnlyRemoteControlBoardLib);
 
     yarp::os::Network yarp; //to initialize the network
 

--- a/src/modules/idyntree-yarp-visualizer/main.cpp
+++ b/src/modules/idyntree-yarp-visualizer/main.cpp
@@ -9,13 +9,10 @@
      */
 
 #include "Visualizer.h"
-YARP_DECLARE_PLUGINS(ReadOnlyRemoteControlBoardLib);
 
 
 int main(int argc, char * argv[])
 {
-    YARP_REGISTER_PLUGINS(ReadOnlyRemoteControlBoardLib);
-
     yarp::os::Network yarp; //to initialize the network
 
     yarp::os::ResourceFinder& rf = yarp::os::ResourceFinder::getResourceFinderSingleton();

--- a/src/modules/idyntree-yarp-visualizer/main.cpp
+++ b/src/modules/idyntree-yarp-visualizer/main.cpp
@@ -31,6 +31,7 @@ int main(int argc, char * argv[])
 
     if (!viz.configure(rf))
     {
+        viz.close();
         return EXIT_FAILURE;
     }
 


### PR DESCRIPTION
In the end, the modifications needed were a lot, but I tested it on the robot and seems to be working fine. The most difficult part has been defining a proper syntax. I hope it is well explained when typing ``--help``. I also added the ``default`` keyword that should work when connecting to a known robot (only ``icub`` or ``icubSim`` for the time being). I have tested it on iCubGenova09 and with iCubGazeboV3, and iCubGazeboV2_5.

**NOTE**: I had to switch the compilation to static by default in order to use the ``ReadOnlyControlBoard`` plugin without installing. I am not sure if I am missing something.

Closes https://github.com/robotology/idyntree-yarp-tools/issues/6