### PR TITLE
Added possibility to connect to WBD to display the net external wrenches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 find_package(YCM REQUIRED)
 find_package(YARP 3.3 REQUIRED)
-find_package(iDynTree 3.0 REQUIRED)
+find_package(iDynTree 3.1.0 REQUIRED)
 find_package(Eigen3 REQUIRED)
 
 

--- a/src/modules/idyntree-yarp-visualizer/Visualizer.cpp
+++ b/src/modules/idyntree-yarp-visualizer/Visualizer.cpp
@@ -347,7 +347,7 @@ void idyntree_yarp_tools::Visualizer::updateWrenchesVisualization()
         if (!vizWrench.second.skip)
         {
             iDynTree::Transform linkTransform = m_viz.modelViz("robot").getWorldFrameTransform(vizWrench.second.frameIndex);
-            iDynTree::Wrench scaledWrenchInWorld = linkTransform * vizWrench.second.scaledWrench;
+            iDynTree::Wrench scaledWrenchInWorld = linkTransform * vizWrench.second.scaledWrench; //the input wrenches are defined in the link frame
             iDynTree::Position originLinear = linkTransform.getPosition();
             iDynTree::Position originAngular = linkTransform.getPosition();
 
@@ -707,7 +707,11 @@ bool idyntree_yarp_tools::Visualizer::neededHelp(const yarp::os::ResourceFinder 
                   << "                                                   --connectToStateExt default" << std::endl
                   << "                                                   When using connectToStateExt, the --controlboards and --joints options are ignored;" << std::endl << std::endl
                   << "--noNetExternalWrenches                            Avoid connecting to WholeBodyDynamics to retrieve the net external wrenches applied on the robot link;" << std::endl << std::endl
-                  << "--netExternalWrenchesPortName <name>               The name of the WholeBodyDynamics port to retrieve the net external wrenches. Default /wholeBodyDynamics/netExternalWrenches:o;"  << std::endl << std::endl
+                  << "--netExternalWrenchesPortName <name>               The name of the WholeBodyDynamics port to retrieve the net external wrenches." << std::endl
+                  << "                                                   The port is supposed to send a bottle of n pairs, where n is the number of links." << std::endl
+                  << "                                                   The first element of each pair is the name of the link. The second element is yet another list of 6 elements containing the value of the" << std::endl
+                  << "                                                   net external wrench, defined in the link frame. The first three elements are the linear part, while the other three are the angular part." << std::endl
+                  << "                                                   Default /wholeBodyDynamics/netExternalWrenches:o;"  << std::endl << std::endl
                   << "--externalForcesMultiplier <multiplier>            The multiplier to scale the visualization of the external forces. Default 0.005"  << std::endl << std::endl
                   << "--externalTorquesMultiplier <multiplier>           The multiplier to scale the visualization of the external torques. Default 0.05"  << std::endl << std::endl
                   << "--externalForcesColor \"(r, g, b)\"                  The color used for the visualization of the external forces. Default \"(1.0, 0.0, 0.0)\";" << std::endl << std::endl

--- a/src/modules/idyntree-yarp-visualizer/Visualizer.cpp
+++ b/src/modules/idyntree-yarp-visualizer/Visualizer.cpp
@@ -62,7 +62,7 @@ iDynTree::Vector3 idyntree_yarp_tools::Visualizer::rgbFromConfig(const yarp::os:
                 rgb[i] = colorList->get(i).asDouble();
                 if (rgb[i] > 1.0 || rgb[i] < 0.0)
                 {
-                    yError() << "The value in position " << i << " (0-based) of " + optionName + " is not value. It needs to be between 0.0 and 1.0.";
+                    yError() << "The value in position " << i << " (0-based) of " + optionName + " is not an expected value. It needs to be between 0.0 and 1.0.";
                     rgb[0] = -1; //r=-1 -> Error
                     return rgb;
                 }
@@ -887,7 +887,7 @@ std::string idyntree_yarp_tools::Visualizer::reconnectToRobot()
         }
         else
         {
-            return "The connection to the robot succeded, but not the connection to the net external wrenches port.";
+            return "The connection to the robot succeeded, but not the connection to the net external wrenches port.";
         }
     }
 }

--- a/src/modules/idyntree-yarp-visualizer/thrifts/VisualizerCommands.thrift
+++ b/src/modules/idyntree-yarp-visualizer/thrifts/VisualizerCommands.thrift
@@ -24,9 +24,9 @@ service VisualizerCommands
 
     /**
      * Attempt to reconnect to the robot.
-     * @return true/false in case of success/failure.
+     * @return A status message. "[ok]" in case of success
      */
-    bool reconnectToRobot();
+    string reconnectToRobot();
 
     /**
      * Get the camera position


### PR DESCRIPTION
It requires https://github.com/robotology/whole-body-estimators/pull/111, but it is not a hard constraint.

It displays 2 arrows for each wrench. One for the force (default red) one for the torque (default blue). 

Example:

![image](https://user-images.githubusercontent.com/18591940/116679270-9f796680-a9aa-11eb-947e-1b7c2adf53f1.png)
