### PR TITLE
Separate options for Qt and Qt Charts 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.0.2] - 2021-07-09
+
+### Added
+- Added `IDYNTREE_YARP_TOOLS_USES_QT_CHARTS` option to disable just the compilation of `idyntree-plotter` that depends on Qt5 Charts.
+
 ## [0.0.1] - 2021-07-08
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ find_package(Qt5 COMPONENTS Widgets QUIET)
 option(IDYNTREE_YARP_TOOLS_USES_QT "Compile the tools that depend on Qt." ${Qt5_FOUND})
 
 find_package(Qt5 COMPONENTS Charts QUIET)
-option(IDYNTREE_YARP_TOOLS_USES_QT_CHARTS "Compile the tools that depend on Qt." ${Qt5_FOUND})
+option(IDYNTREE_YARP_TOOLS_USES_QT_CHARTS "Compile the tools that depend on Qt Charts." ${Qt5_FOUND})
 
 if(IDYNTREE_YARP_TOOLS_USES_QT AND NOT IDYNTREE_YARP_TOOLS_USES_QT_CHARTS)
   find_package(Qt5 COMPONENTS Widgets REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,9 +71,17 @@ if(IDYNTREE_YARP_TOOLS_USES_ICUB_MAIN)
   find_package(ICUB REQUIRED)
 endif()
 
-find_package(Qt5 COMPONENTS Widgets Charts QUIET)
+find_package(Qt5 COMPONENTS Widgets QUIET)
 option(IDYNTREE_YARP_TOOLS_USES_QT "Compile the tools that depend on Qt." ${Qt5_FOUND})
-if(IDYNTREE_YARP_TOOLS_USES_QT)
+
+find_package(Qt5 COMPONENTS Charts QUIET)
+option(IDYNTREE_YARP_TOOLS_USES_QT_CHARTS "Compile the tools that depend on Qt." ${Qt5_FOUND})
+
+if(IDYNTREE_YARP_TOOLS_USES_QT AND NOT IDYNTREE_YARP_TOOLS_USES_QT_CHARTS)
+  find_package(Qt5 COMPONENTS Widgets REQUIRED)
+endif()
+
+if(IDYNTREE_YARP_TOOLS_USES_QT AND IDYNTREE_YARP_TOOLS_USES_QT_CHARTS)
   find_package(Qt5 COMPONENTS Widgets Charts REQUIRED)
 endif()
 

--- a/src/modules/CMakeLists.txt
+++ b/src/modules/CMakeLists.txt
@@ -6,7 +6,7 @@ if(IDYNTREE_YARP_TOOLS_USES_ICUB_MAIN)
   add_subdirectory(urdf2dh)
 endif()
 
-if(IDYNTREE_YARP_TOOLS_USES_QT)
+if(IDYNTREE_YARP_TOOLS_USES_QT AND IDYNTREE_YARP_TOOLS_USES_QT_CHARTS)
   add_subdirectory(idyntree-plotter)
 endif()
 


### PR DESCRIPTION
Apparently the previous implicit behavior of robotology-superbuild was to compile `idyntree-sole-gui` and not `idyntree-plotter`, so let's have options to enable us to do that.