### PR TITLE
Remove quotes from thrift commands for compatibility with YARP 3.5.100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Fixed compatibility with YARP 3.5.100 (https://github.com/robotology/idyntree-yarp-tools/pull/20).
+
 ## [0.0.2] - 2021-07-09
 
 ### Added

--- a/src/modules/idyntree-yarp-visualizer/thrifts/VisualizerCommands.thrift
+++ b/src/modules/idyntree-yarp-visualizer/thrifts/VisualizerCommands.thrift
@@ -24,7 +24,7 @@ service VisualizerCommands
 
     /**
      * Attempt to reconnect to the robot.
-     * @return A status message. "[ok]" in case of success
+     * @return A status message. `[ok]` in case of success
      */
     string reconnectToRobot();
 


### PR DESCRIPTION
See https://github.com/robotology/robotology-superbuild/issues/900