### PR TITLE
Fix conda CI by using macos-10.15

### DIFF
--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         build_type: [Release]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-10.15]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Xcode 13 YARP compilation with conda compiler fails with:
~~~
2022-02-22T03:56:11.8650330Z [158/1269] Building CXX object src/libYARP_os/src/CMakeFiles/YARP_os.dir/yarp/os/impl/macos/MacOSAPI.mm.o
2022-02-22T03:56:11.8751110Z FAILED: src/libYARP_os/src/CMakeFiles/YARP_os.dir/yarp/os/impl/macos/MacOSAPI.mm.o 
2022-02-22T03:56:11.8855750Z /usr/local/miniconda/envs/test/bin/x86_64-apple-darwin13.4.0-clang++ -DBUILDING_YARP -DYARP_HAS_ACE -DYARP_HAS_Libedit -DYARP_os_EXPORTS -D__ACE_INLINE__ -I/Users/runner/work/idyntree-yarp-tools/idyntree-yarp-tools/yarp/src/libYARP_os/src -I/Users/runner/work/idyntree-yarp-tools/idyntree-yarp-tools/yarp/src/libYARP_conf/src -I/Users/runner/work/idyntree-yarp-tools/idyntree-yarp-tools/yarp/build/src/libYARP_conf/src -isystem /Users/runner/work/idyntree-yarp-tools/idyntree-yarp-tools/yarp/extern/hmac/hmac -Wall -Wextra -Wsign-compare -Wpointer-arith -Winit-self -Wnon-virtual-dtor -Wcast-align -Wunused -Wvla -Wmissing-include-dirs -Wreorder -Wsizeof-pointer-memaccess -Woverloaded-virtual -Wtautological-undefined-compare -Wmismatched-new-delete -Wparentheses-equality -Wundef -Wredundant-decls -Wunknown-pragmas -Wunused-result -Wc++2a-compat -Wheader-guard -Wignored-attributes -Wnewline-eof -Wdangling-else -Wgcc-compat -Wmicrosoft-exists -Wstatic-inline-explicit-instantiation -Wmisleading-indentation -Wtautological-compare -Winconsistent-missing-override -Wsuggest-override -Wnull-conversion  -Wno-unused-parameter  -Wdeprecated-declarations -march=core2 -mtune=haswell -mssse3 -ftree-vectorize -fPIC -fPIE -fstack-protector-strong -O2 -pipe -stdlib=libc++ -fvisibility-inlines-hidden -std=c++14 -fmessage-length=0 -isystem /usr/local/miniconda/envs/test/include -O3 -DNDEBUG -isysroot /Applications/Xcode_13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -std=c++17 -MD -MT src/libYARP_os/src/CMakeFiles/YARP_os.dir/yarp/os/impl/macos/MacOSAPI.mm.o -MF src/libYARP_os/src/CMakeFiles/YARP_os.dir/yarp/os/impl/macos/MacOSAPI.mm.o.d -o src/libYARP_os/src/CMakeFiles/YARP_os.dir/yarp/os/impl/macos/MacOSAPI.mm.o -c /Users/runner/work/idyntree-yarp-tools/idyntree-yarp-tools/yarp/src/libYARP_os/src/yarp/os/impl/macos/MacOSAPI.mm
2022-02-22T03:56:11.8952770Z In file included from /Users/runner/work/idyntree-yarp-tools/idyntree-yarp-tools/yarp/src/libYARP_os/src/yarp/os/impl/macos/MacOSAPI.mm:8:
2022-02-22T03:56:11.9053550Z In file included from /Applications/Xcode_13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Foundation.framework/Headers/Foundation.h:12:
2022-02-22T03:56:11.9154620Z /Applications/Xcode_13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSBundle.h:91:143: error: function does not return NSString
2022-02-22T03:56:11.9256580Z - (NSAttributedString *)localizedAttributedStringForKey:(NSString *)key value:(nullable NSString *)value table:(nullable NSString *)tableName NS_FORMAT_ARGUMENT(1) NS_REFINED_FOR_SWIFT API_AVAILABLE(macos(12.0), ios(15.0), watchos(8.0), tvos(15.0));
2022-02-22T03:56:11.9357900Z                                                          ~~~~~~~~~~~~~~                                                                       ^                  ~
2022-02-22T03:56:11.9459710Z /Applications/Xcode_13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSObjCRuntime.h:103:48: note: expanded from macro 'NS_FORMAT_ARGUMENT'
2022-02-22T03:56:11.9561080Z         #define NS_FORMAT_ARGUMENT(A) __attribute__ ((format_arg(A)))
2022-02-22T03:56:11.9662190Z                                                       ^          ~
2022-02-22T03:56:11.9763880Z 1 error generated.
2022-02-22T03:56:13.8038810Z [159/1269] Building CXX object src/libYARP_sig/src/CMakeFiles/YARP_sig.dir/yarp/sig/Image.cpp.o
2022-02-22T03:56:14.2502110Z [160/1269] Building CXX object src/libYARP_sig/src/CMakeFiles/YARP_sig.dir/yarp/sig/ImageUtils.cpp.o
2022-02-22T03:56:15.6176590Z [161/1269] Building CXX object src/libYARP_sig/src/CMakeFiles/YARP_sig.dir/yarp/sig/ImageFile.cpp.o
2022-02-22T03:56:15.6201490Z /Users/runner/work/idyntree-yarp-tools/idyntree-yarp-tools/yarp/src/libYARP_sig/src/yarp/sig/ImageFile.cpp:419:17: warning: cast from 'char *' to 'size_t *' (aka 'unsigned long *') increases required alignment from 1 to 8 [-Wcast-align]
2022-02-22T03:56:15.6224170Z     size_t h = ((size_t*)(dataReadInCompressed))[0]; //byte 0
2022-02-22T03:56:15.6242000Z                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2022-02-22T03:56:15.6292270Z /Users/runner/work/idyntree-yarp-tools/idyntree-yarp-tools/yarp/src/libYARP_sig/src/yarp/sig/ImageFile.cpp:420:17: warning: cast from 'char *' to 'size_t *' (aka 'unsigned long *') increases required alignment from 1 to 8 [-Wcast-align]
2022-02-22T03:56:15.6320830Z     size_t w = ((size_t*)(dataReadInCompressed))[1]; //byte 8, because size_t is 8 bytes long
2022-02-22T03:56:15.6321180Z                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2022-02-22T03:56:15.6329860Z 2 warnings generated.
2022-02-22T03:56:19.7723530Z [162/1269] Building CXX object src/libYARP_sig/src/CMakeFiles/YARP_sig.dir/yarp/sig/Image.copyPixels.cpp.o
2022-02-22T03:56:19.7724820Z ninja: build stopped: subcommand failed.
2022-02-22T03:56:19.7770830Z ##[error]Process completed with exit code 1.
2022-02-22T03:56:19.8326130Z Post job cleanup.
2022-02-22T03:56:20.0560300Z [command]/usr/local/bin/git version
2022-02-22T03:56:20.1154300Z git version 2.35.1
2022-02-22T03:56:20.1223590Z [command]/usr/local/bin/git config --local --name-only --get-regexp core\.sshCommand
2022-02-22T03:56:20.1733510Z [command]/usr/local/bin/git submodule foreach --recursive git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :
2022-02-22T03:56:20.3644530Z [command]/usr/local/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
2022-02-22T03:56:20.3724040Z http.https://github.com/.extraheader
2022-02-22T03:56:20.3744370Z [command]/usr/local/bin/git config --local --unset-all http.https://github.com/.extraheader
2022-02-22T03:56:20.3864880Z [command]/usr/local/bin/git submodule foreach --recursive git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :
~~~

so we stick to Xcode 12 for now.