### PR TITLE
Fix Conda CI by using windows-2019

### DIFF
--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         build_type: [Release]
-        os: [ubuntu-latest, windows-latest, macos-10.15]
+        os: [ubuntu-latest, windows-2019, macos-10.15]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
As we are using the VS 2019, we need the corresponding image.