### PR TITLE
Remove deprecated YARP header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Remove use of deprecated YARP header to ensure compatibility with YARP 3.8 (https://github.com/robotology/idyntree-yarp-tools/pull/32).
+
 ## [0.0.5] - 2022-05-27
 
 ### Fixed

--- a/src/lib/ReadOnlyRemoteControlBoard/stateExtendedReader.h
+++ b/src/lib/ReadOnlyRemoteControlBoard/stateExtendedReader.h
@@ -20,7 +20,6 @@
 #include <yarp/os/Thread.h>
 #include <yarp/os/Vocab.h>
 #include <yarp/os/Stamp.h>
-#include <yarp/os/Mutex.h>
 #include <yarp/os/Log.h>
 
 #include <yarp/sig/Vector.h>


### PR DESCRIPTION
`yarp/os/Mutex.h` will not be included in YARP 3.8 .