### PR TITLE
CI: Install almost all conda dependencies in one step

### DIFF
--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -34,10 +34,7 @@ jobs:
       run: |
         # Workaround for https://github.com/conda-incubator/setup-miniconda/issues/186
         conda config --remove channels defaults
-        # Compilation related dependencies
-        mamba install cmake compilers make ninja pkg-config
-        # Actual dependencies
-        mamba install -c conda-forge qt
+        mamba install -c conda-forge -c robotology cmake compilers make ninja pkg-config qt-main yarp icub-main idyntree
 
     # Additional dependencies useful only on Linux
     - name: Dependencies [Conda/Linux]
@@ -47,12 +44,6 @@ jobs:
         # Additional dependencies only useful on Linux
         # See https://github.com/robotology/robotology-superbuild/issues/477
         mamba install expat-cos6-x86_64 libselinux-cos6-x86_64 libxau-cos6-x86_64 libxcb-cos6-x86_64 libxdamage-cos6-x86_64 libxext-cos6-x86_64 libxfixes-cos6-x86_64 libxxf86vm-cos6-x86_64 mesalib mesa-libgl-cos6-x86_64 mesa-libgl-devel-cos6-x86_64
-
-    - name: Dependencies
-      shell: bash -l {0}
-      run: |
-        # Actual dependencies
-        mamba install -c conda-forge -c robotology yarp icub-main idyntree
 
     - name: Configure [Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')


### PR DESCRIPTION
Fix https://github.com/robotology/idyntree-yarp-tools/issues/25 .

In general, it is a good idea to install all dependencies at once, to speedup the installation process and avoid confusing the dependency solver.
Furthermore, switch from qt to qt-main.