### PR TITLE
Fix iDynTree deprecation warning

### DIFF
--- a/src/modules/idyntree-yarp-visualizer/CMakeLists.txt
+++ b/src/modules/idyntree-yarp-visualizer/CMakeLists.txt
@@ -10,7 +10,7 @@ yarp_add_idl(THRIFT_GEN_FILES ${THRIFTS})
 
 add_executable(${MODULE_NAME} ${SRC} ${HDR} ${THRIFT_GEN_FILES})
 target_link_libraries(${MODULE_NAME} PRIVATE idyntree-yarp-utilities ReadOnlyRemoteControlBoardLib Eigen3::Eigen
-                                             iDynTree::idyntree-core iDynTree::idyntree-modelio-urdf iDynTree::idyntree-visualization
+                                             iDynTree::idyntree-core iDynTree::idyntree-modelio iDynTree::idyntree-visualization
                                              YARP::YARP_init YARP::YARP_os)
 
 install(TARGETS ${MODULE_NAME} DESTINATION bin)


### PR DESCRIPTION
Fix https://github.com/robotology/idyntree-yarp-tools/issues/29 .