### PR TITLE
Fix conda-ci GitHub Action CI by using mambaforge directly

### DIFF
--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         build_type: [Release]
-        os: [ubuntu-latest, windows-latest, macos-10.15]
+        os: [ubuntu-latest, windows-2019, macos-10.15]
       fail-fast: false
 
     steps:

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -23,9 +23,8 @@ jobs:
 
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        mamba-version: "*"
-        channels: conda-forge,robotology
-        channel-priority: true
+        miniforge-variant: Mambaforge
+        miniforge-version: latest
 
     - uses: rlespinasse/github-slug-action@v3.x
 


### PR DESCRIPTION
Currently the CI is failing on Linux and Windows with a weird conflict error. This is due to the fact that we are install mamba (from the conda-forge channel) on the top of miniconda3 (that by default install all the packages from the defaults channel). To make an analogy in apt world, this is like installing Debian, and then trying to install packages from the Ubuntu repo: something can go wrong.

To solve this problem, we install [mambaforge](https://github.com/conda-forge/miniforge) (a installer like miniconda3 but already using conda-forge packages) directly, so we always and only use packages from the conda-forge channel. 

Similar to:
* https://github.com/robotology/robotology-superbuild/pull/840
* https://github.com/robotology/robometry/pull/141
* https://github.com/robotology-playground/yarp-devices-ros2/pull/44
* https://github.com/gazebosim/gazebo-classic/pull/3287