### PR TITLE
The remapper connector will not fail if some board of joint is not available

### DIFF
--- a/src/lib/RobotConnectors/RobotConnectors.cpp
+++ b/src/lib/RobotConnectors/RobotConnectors.cpp
@@ -8,7 +8,6 @@
 #include <yarp/os/LogStream.h>
 #include <iDynTree/Core/Utils.h>
 #include <yarp/dev/IAxisInfo.h>
-#include <yarp/dev/IPositionControl.h>
 #include "RobotConnectors.h"
 #include <algorithm>
 
@@ -162,7 +161,7 @@ bool RemapperConnector::addJointsFromBoard(const std::string &name,
     }
 
     yarp::dev::IAxisInfo* axisInfo{nullptr};
-    yarp::dev::IPositionControl* pos{nullptr};
+    yarp::dev::IEncodersTimed* pos{nullptr};
 
     if (!m_driver.view(pos) || !pos)
     {

--- a/src/lib/RobotConnectors/RobotConnectors.cpp
+++ b/src/lib/RobotConnectors/RobotConnectors.cpp
@@ -324,11 +324,16 @@ bool RemapperConnector::connectToRobot()
             boardsInfo << "- " << cb << std::endl;
         }
 
-        boardsInfo << "Connected to the following joints:" <<std::endl;
+        yInfo() << boardsInfo.str();
+
+        std::stringstream jointsInfo;
+        jointsInfo << "Connected to the following joints:" <<std::endl;
         for (const Joint& joint : m_availableJoints)
         {
-            boardsInfo << "- " << joint.name << std::endl;
+            jointsInfo << "- " << joint.name << std::endl;
         }
+
+        yInfo() << jointsInfo.str();
 
     }
 

--- a/src/lib/RobotConnectors/RobotConnectors.h
+++ b/src/lib/RobotConnectors/RobotConnectors.h
@@ -23,6 +23,7 @@
 #include <memory>
 #include <functional>
 #include <unordered_map>
+#include <map>
 
 
 
@@ -76,12 +77,28 @@ public:
 
 class RemapperConnector : public BasicConnector
 {
+    struct Joint {
+        std::string name;
+        size_t desiredPosition;
+    };
 
     std::vector<std::string> m_controlBoards;
+    std::vector<std::string> m_availableControlBoards;
+    std::vector<Joint> m_availableJoints;
+    iDynTree::VectorDynSize m_availableJointsInDeg;
     yarp::dev::PolyDriver m_robotDevice;
     yarp::dev::IEncodersTimed *m_encodersInterface{nullptr};
 
     bool getOrGuessControlBoardsFromFile(const yarp::os::Searchable &inputConf);
+
+    bool addJointsFromBoard(const std::string& name,
+                            const std::string& robot,
+                            const std::string& controlBoard,
+                            const std::unordered_map<std::string, size_t> &desiredJointsMap);
+
+    void getAvailableJoints(const std::string& name, const std::string& robot, const std::vector<std::string> &desiredJoints);
+
+    void fillDesiredJointsInDeg();
 
 public:
 


### PR DESCRIPTION
This is handy on ergocub, where there are some joints in the model (in the fingers) that are named differently from the robot ones 